### PR TITLE
Fix HTTPS includes in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,12 @@
     <link href="static/css/bootstrap.min.css" rel="stylesheet">
     <link href="static/css/bootstrap-responsive.min.css" rel="stylesheet">
     <link href="static/css/webdictaat.css" rel="stylesheet">
-    <link rel="shortcut icon" href="http://www.avans.nl/favicon.64.png">
+    <link rel="shortcut icon" href="https://www.avans.nl/favicon.64.png">
 
     <script src="static/js/jquery-1.9.1.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.4.3/angular.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.15/angular-ui-router.min.js"></script>
-    <script src="http://advans.herokuapp.com/js/pointypony.js"></script>
+    <script src="https://advans.herokuapp.com/js/pointypony.js"></script>
     <script src="app/app.js"></script>
     <script src="static/js/jquery-ui.js"></script>
     <script src="static/ace/ace.js"></script>


### PR DESCRIPTION
Rewrite both the favicon link and the pointypony.js to https, so a install on a SSL-{enabled,enforced} host won't break the webdictaat.
